### PR TITLE
chore: 添加.gitignore文件以忽略不必要的文件和目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.DS_Store
+.env


### PR DESCRIPTION
添加.gitignore文件来忽略node_modules、dist、.DS_Store和.env等目录和文件，避免这些文件被提交到版本控制中，保持仓库的整洁。